### PR TITLE
Armazena conteúdo modificado junto do registro de mudança

### DIFF
--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -184,7 +184,7 @@ class ChangesStore(interfaces.ChangesDataStore):
         return self._collection.find(
             {"_id": {"$gt": since}},
             sort=[("_id", pymongo.ASCENDING)],
-            projection={"_id": False},
+            projection={"_id": False, "content": False, "content_type": False},
         ).limit(limit)
 
 

--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -12,6 +12,7 @@ import logging
 import json
 
 import pymongo
+from bson.objectid import ObjectId
 
 from . import interfaces
 from . import exceptions
@@ -189,6 +190,15 @@ class ChangesStore(interfaces.ChangesDataStore):
             sort=[("timestamp", pymongo.ASCENDING)],
             projection={"_id": False, "content_gz": False, "content_type": False},
         ).limit(limit)
+
+    def fetch(self, id: str) -> dict:
+        change = self._collection.find_one({"_id": ObjectId(id)})
+        if change:
+            return change
+        else:
+            raise exceptions.DoesNotExist(
+                "cannot fetch data with id " '"%s": data does not exist' % id
+            )
 
 
 class DocumentStore(BaseStore):

--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -184,7 +184,7 @@ class ChangesStore(interfaces.ChangesDataStore):
         return self._collection.find(
             {"_id": {"$gt": since}},
             sort=[("_id", pymongo.ASCENDING)],
-            projection={"_id": False, "content": False, "content_type": False},
+            projection={"_id": False, "content_gz": False, "content_type": False},
         ).limit(limit)
 
 

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -8,6 +8,7 @@ import time
 import os
 import functools
 import logging
+import json
 
 import requests
 from lxml import etree

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -262,6 +262,7 @@ class Document:
     _timestamp_pattern = (
         r"^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}(:[0-9]{2})?Z)?$"
     )
+    data_type = "text/xml"
 
     def __init__(self, id=None, manifest=None):
         assert any([id, manifest])
@@ -456,6 +457,8 @@ class Document:
             target_node.attrib["{http://www.w3.org/1999/xlink}href"] = version_href
 
         return etree.tostring(xml_tree, encoding="utf-8", pretty_print=False)
+
+    data_bytes = data
 
     def _latest_or_default(self):
         try:
@@ -687,6 +690,8 @@ class DocumentsBundle:
     e abertos, Ahead of Print, Documentos Provisórios, Erratas e Retratações.
     """
 
+    data_type = "application/json"
+
     def __init__(self, id: str = None, manifest: dict = None):
         assert any([id, manifest])
         self.manifest = manifest or BundleManifest.new(id)
@@ -700,6 +705,11 @@ class DocumentsBundle:
             attr: value[-1][-1] for attr, value in _manifest["metadata"].items()
         }
         return _manifest
+
+    def data_bytes(self) -> bytes:
+        """Retorna `self.data()` codificado em utf-8.
+        """
+        return json.dumps(self.data()).encode("utf-8")
 
     @property
     def manifest(self):
@@ -807,6 +817,8 @@ class Journal:
     DocumentsBundle.
     """
 
+    data_type = "application/json"
+
     def __init__(self, id: str = None, manifest: dict = None):
         assert any([id, manifest])
         self.manifest = manifest or BundleManifest.new(id)
@@ -837,6 +849,11 @@ class Journal:
             _manifest["metadata"][key] = value[-1][-1]
 
         return _manifest
+
+    def data_bytes(self) -> bytes:
+        """Retorna `self.data()` codificado em utf-8.
+        """
+        return json.dumps(self.data()).encode("utf-8")
 
     @property
     def mission(self):

--- a/documentstore/interfaces.py
+++ b/documentstore/interfaces.py
@@ -35,6 +35,10 @@ class ChangesDataStore(abc.ABC):
     def filter(self, since: str = "", limit: int = 500) -> list:
         pass
 
+    @abc.abstractmethod
+    def fetch(self, id: str):
+        pass
+
 
 class Session(abc.ABC):
     """Concentra os pontos de acesso aos repositórios de dados.

--- a/documentstore/kernelctl.py
+++ b/documentstore/kernelctl.py
@@ -1,0 +1,71 @@
+import sys
+import argparse
+import logging
+import pkg_resources
+
+from documentstore import adapters
+
+
+LOGGER = logging.getLogger(__name__)
+
+EPILOG = """\
+Copyright 2019 SciELO <scielo-dev@googlegroups.com>.
+Licensed under the terms of the BSD license. Please see LICENSE in the source
+code for more information.
+"""
+
+VERSION = pkg_resources.get_distribution("scielo-kernel").version
+
+LOGGER_FMT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def _create_indexes(args):
+    mongo = adapters.MongoDB(args.dsn)
+    mongo.create_indexes()
+
+
+def cli(argv=None):
+    if argv is None:
+        argv = sys.argv
+    parser = argparse.ArgumentParser(
+        description="SciELO Kernel command line utility.", epilog=EPILOG
+    )
+    parser.add_argument("-v", "--version", action="version", version=VERSION)
+    parser.add_argument("--loglevel", default="")
+    subparsers = parser.add_subparsers()
+
+    parser_create_indexes = subparsers.add_parser(
+        "create-indexes",
+        help="Create all database indexes",
+        description="This operation may cause outages. "
+        "If you are using replica sets please read "
+        "https://docs.mongodb.com/manual/core/index-creation/#index-operations-replicated-build",
+    )
+    parser_create_indexes.add_argument(
+        "dsn", help="DSN for MongoDB node where indexes will be created."
+    )
+    parser_create_indexes.set_defaults(func=_create_indexes)
+
+    args = parser.parse_args()
+    # todas as mensagens serão omitidas se level > 50
+    logging.basicConfig(
+        level=getattr(logging, args.loglevel.upper(), 999), format=LOGGER_FMT
+    )
+    return args.func(args)
+
+
+def main():
+    try:
+        sys.exit(cli())
+    except KeyboardInterrupt:
+        LOGGER.info("Got a Ctrl+C. Terminating the program.")
+        # É convencionado no shell que o programa finalizado pelo signal de
+        # código N deve retornar o código N + 128.
+        sys.exit(130)
+    except Exception as exc:
+        LOGGER.exception(exc)
+        sys.exit("An unexpected error has occurred: %s" % exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -450,6 +450,17 @@ class FetchChanges(CommandHandler):
         return session.changes.filter(since=since, limit=limit)
 
 
+class FetchChange(CommandHandler):
+    """Recupera registro de mudança de entidade.
+
+    :param id: Identificador da mudança a ser recuperada.
+    """
+
+    def __call__(self, id: str) -> dict:
+        session = self.Session()
+        return session.changes.fetch(id=id)
+
+
 class RegisterRenditionVersion(CommandHandler):
     """Registra uma nova versão de uma manifestação do documento já registrado.
 
@@ -654,6 +665,7 @@ def get_handlers(
         "remove_issue_from_journal": RemoveIssueFromJournal(SessionWrapper),
         "update_issues_in_journal": UpdateIssuesInJournal(SessionWrapper),
         "fetch_changes": FetchChanges(SessionWrapper),
+        "fetch_change": FetchChange(SessionWrapper),
         "set_ahead_of_print_bundle_to_journal": SetAheadOfPrintBundleToJournal(
             SessionWrapper
         ),

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -535,135 +535,69 @@ class DeleteDocument(CommandHandler):
         return result
 
 
-def log_change(data, session, now=utcnow, entity="", deleted=False, content_type=""):
-    def _get_content():
-        instance = None
-        for key in ["document", "bundle", "journal"]:
-            try:
-                instance = data[key]
-            except KeyError:
-                continue
-            else:
-                break
-
-        if instance is None:
-            return ""
-        else:
-            return instance.data()
-
+def log_change(data, session, now=utcnow, entity="", deleted=False):
     change = {"timestamp": now(), "entity": entity, "id": data["id"]}
 
     if deleted:
         change["deleted"] = True
-
-    content = _get_content()
-    if content:
-        change["content"] = content
-        change["content_type"] = content_type
+    else:
+        change["content"] = data["instance"].data_bytes()
+        change["content_type"] = data["instance"].data_type
 
     session.changes.add(change)
 
 
 DEFAULT_SUBSCRIBERS = [
-    (
-        Events.DOCUMENT_REGISTERED,
-        functools.partial(log_change, entity="Document", content_type="text/xml"),
-    ),
+    (Events.DOCUMENT_REGISTERED, functools.partial(log_change, entity="Document")),
     (
         Events.DOCUMENT_VERSION_REGISTERED,
-        functools.partial(log_change, entity="Document", content_type="text/xml"),
+        functools.partial(log_change, entity="Document"),
     ),
-    (
-        Events.ASSET_VERSION_REGISTERED,
-        functools.partial(log_change, entity="Document", content_type="text/xml"),
-    ),
+    (Events.ASSET_VERSION_REGISTERED, functools.partial(log_change, entity="Document")),
     (
         Events.DOCUMENTSBUNDLE_CREATED,
-        functools.partial(
-            log_change, entity="DocumentsBundle", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="DocumentsBundle"),
     ),
     (
         Events.DOCUMENTSBUNDLE_METATADA_UPDATED,
-        functools.partial(
-            log_change, entity="DocumentsBundle", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="DocumentsBundle"),
     ),
     (
         Events.DOCUMENT_ADDED_TO_DOCUMENTSBUNDLE,
-        functools.partial(
-            log_change, entity="DocumentsBundle", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="DocumentsBundle"),
     ),
     (
         Events.DOCUMENT_INSERTED_TO_DOCUMENTSBUNDLE,
-        functools.partial(
-            log_change, entity="DocumentsBundle", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="DocumentsBundle"),
     ),
-    (
-        Events.JOURNAL_CREATED,
-        functools.partial(
-            log_change, entity="Journal", content_type="application/json"
-        ),
-    ),
-    (
-        Events.JOURNAL_METATADA_UPDATED,
-        functools.partial(
-            log_change, entity="Journal", content_type="application/json"
-        ),
-    ),
-    (
-        Events.ISSUE_ADDED_TO_JOURNAL,
-        functools.partial(
-            log_change, entity="Journal", content_type="application/json"
-        ),
-    ),
-    (
-        Events.ISSUE_INSERTED_TO_JOURNAL,
-        functools.partial(
-            log_change, entity="Journal", content_type="application/json"
-        ),
-    ),
+    (Events.JOURNAL_CREATED, functools.partial(log_change, entity="Journal")),
+    (Events.JOURNAL_METATADA_UPDATED, functools.partial(log_change, entity="Journal")),
+    (Events.ISSUE_ADDED_TO_JOURNAL, functools.partial(log_change, entity="Journal")),
+    (Events.ISSUE_INSERTED_TO_JOURNAL, functools.partial(log_change, entity="Journal")),
     (
         Events.ISSUE_REMOVED_FROM_JOURNAL,
-        functools.partial(
-            log_change, entity="Journal", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="Journal"),
     ),
     (
         Events.AHEAD_OF_PRINT_BUNDLE_SET_TO_JOURNAL,
-        functools.partial(
-            log_change, entity="Journal", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="Journal"),
     ),
     (
         Events.AHEAD_OF_PRINT_BUNDLE_REMOVED_FROM_JOURNAL,
-        functools.partial(
-            log_change, entity="Journal", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="Journal"),
     ),
     (
         Events.RENDITION_VERSION_REGISTERED,
-        functools.partial(
-            log_change, entity="DocumentRendition", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="DocumentRendition"),
     ),
     (
         Events.DOCUMENT_DELETED,
         functools.partial(log_change, entity="Document", deleted=True),
     ),
-    (
-        Events.JOURNAL_ISSUES_UPDATED,
-        functools.partial(
-            log_change, entity="Journal", content_type="application/json"
-        ),
-    ),
+    (Events.JOURNAL_ISSUES_UPDATED, functools.partial(log_change, entity="Journal")),
     (
         Events.ISSUE_DOCUMENTS_UPDATED,
-        functools.partial(
-            log_change, entity="DocumentsBundle", content_type="application/json"
-        ),
+        functools.partial(log_change, entity="DocumentsBundle"),
     ),
 ]
 

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -3,6 +3,7 @@ import difflib
 import functools
 from io import BytesIO
 from enum import Enum, auto
+import gzip
 
 from clea import join as clea_join, core as clea_core
 
@@ -535,13 +536,15 @@ class DeleteDocument(CommandHandler):
         return result
 
 
-def log_change(data, session, now=utcnow, entity="", deleted=False):
+def log_change(
+    data, session, now=utcnow, entity="", deleted=False, compress=gzip.compress
+):
     change = {"timestamp": now(), "entity": entity, "id": data["id"]}
 
     if deleted:
         change["deleted"] = True
     else:
-        change["content"] = data["instance"].data_bytes()
+        change["content_gz"] = compress(data["instance"].data_bytes())
         change["content_type"] = data["instance"].data_type
 
     session.changes.add(change)

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -72,7 +72,7 @@ class BaseRegisterDocument(CommandHandler):
         self._persist(session, document)
         self._notify(
             session,
-            {"document": document, "id": id, "data_url": data_url, "assets": assets},
+            {"instance": document, "id": id, "data_url": data_url, "assets": assets},
         )
 
 
@@ -179,7 +179,7 @@ class RegisterAssetVersion(CommandHandler):
         session.notify(
             Events.ASSET_VERSION_REGISTERED,
             {
-                "document": document,
+                "instance": document,
                 "id": id,
                 "asset_id": asset_id,
                 "asset_url": asset_url,
@@ -249,7 +249,7 @@ class CreateDocumentsBundle(CommandHandler):
         result = session.documents_bundles.add(_bundle)
         session.notify(
             Events.DOCUMENTSBUNDLE_CREATED,
-            {"bundle": _bundle, "id": id, "docs": docs, "metadata": metadata},
+            {"instance": _bundle, "id": id, "docs": docs, "metadata": metadata},
         )
         return result
 
@@ -269,7 +269,7 @@ class UpdateDocumentsBundleMetadata(CommandHandler):
         session.documents_bundles.update(_bundle)
         session.notify(
             Events.DOCUMENTSBUNDLE_METATADA_UPDATED,
-            {"bundle": _bundle, "id": id, "metadata": metadata},
+            {"instance": _bundle, "id": id, "metadata": metadata},
         )
 
 
@@ -281,7 +281,7 @@ class AddDocumentToDocumentsBundle(CommandHandler):
         session.documents_bundles.update(_bundle)
         session.notify(
             Events.DOCUMENT_ADDED_TO_DOCUMENTSBUNDLE,
-            {"bundle": _bundle, "id": id, "doc": doc},
+            {"instance": _bundle, "id": id, "doc": doc},
         )
 
 
@@ -293,7 +293,7 @@ class InsertDocumentToDocumentsBundle(CommandHandler):
         session.documents_bundles.update(_bundle)
         session.notify(
             Events.DOCUMENT_INSERTED_TO_DOCUMENTSBUNDLE,
-            {"bundle": _bundle, "id": id, "index": index, "doc": doc},
+            {"instance": _bundle, "id": id, "index": index, "doc": doc},
         )
 
 
@@ -313,7 +313,8 @@ class UpdateDocumentInDocumentsBundle(CommandHandler):
 
         session.documents_bundles.update(_bundle)
         session.notify(
-            Events.ISSUE_DOCUMENTS_UPDATED, {"bundle": _bundle, "id": id, "docs": docs}
+            Events.ISSUE_DOCUMENTS_UPDATED,
+            {"instance": _bundle, "id": id, "docs": docs},
         )
 
 
@@ -326,7 +327,7 @@ class CreateJournal(CommandHandler):
         result = session.journals.add(_journal)
         session.notify(
             Events.JOURNAL_CREATED,
-            {"journal": _journal, "id": id, "metadata": metadata},
+            {"instance": _journal, "id": id, "metadata": metadata},
         )
         return result
 
@@ -350,7 +351,7 @@ class UpdateJournalMetadata(CommandHandler):
         session.journals.update(_journal)
         session.notify(
             Events.JOURNAL_METATADA_UPDATED,
-            {"id": id, "metadata": metadata, "journal": _journal},
+            {"id": id, "metadata": metadata, "instance": _journal},
         )
 
 
@@ -362,7 +363,7 @@ class AddIssueToJournal(CommandHandler):
         session.journals.update(_journal)
         session.notify(
             Events.ISSUE_ADDED_TO_JOURNAL,
-            {"journal": _journal, "id": id, "issue": issue},
+            {"instance": _journal, "id": id, "issue": issue},
         )
 
 
@@ -374,7 +375,7 @@ class InsertIssueToJournal(CommandHandler):
         session.journals.update(_journal)
         session.notify(
             Events.ISSUE_INSERTED_TO_JOURNAL,
-            {"journal": _journal, "id": id, "index": index, "issue": issue},
+            {"instance": _journal, "id": id, "index": index, "issue": issue},
         )
 
 
@@ -395,7 +396,7 @@ class UpdateIssuesInJournal(CommandHandler):
         session.journals.update(_journal)
         session.notify(
             Events.JOURNAL_ISSUES_UPDATED,
-            {"journal": _journal, "id": id, "issues": issues},
+            {"instance": _journal, "id": id, "issues": issues},
         )
 
 
@@ -407,7 +408,7 @@ class RemoveIssueFromJournal(CommandHandler):
         session.journals.update(_journal)
         session.notify(
             Events.ISSUE_REMOVED_FROM_JOURNAL,
-            {"journal": _journal, "id": id, "issue": issue},
+            {"instance": _journal, "id": id, "issue": issue},
         )
 
 
@@ -419,7 +420,7 @@ class SetAheadOfPrintBundleToJournal(CommandHandler):
         session.journals.update(_journal)
         session.notify(
             Events.AHEAD_OF_PRINT_BUNDLE_SET_TO_JOURNAL,
-            {"journal": _journal, "id": id, "aop": aop},
+            {"instance": _journal, "id": id, "aop": aop},
         )
 
 
@@ -431,7 +432,7 @@ class RemoveAheadOfPrintBundleFromJournal(CommandHandler):
         session.journals.update(_journal)
         session.notify(
             Events.AHEAD_OF_PRINT_BUNDLE_REMOVED_FROM_JOURNAL,
-            {"journal": _journal, "id": id},
+            {"instance": _journal, "id": id},
         )
 
 
@@ -483,7 +484,7 @@ class RegisterRenditionVersion(CommandHandler):
         session.notify(
             Events.RENDITION_VERSION_REGISTERED,
             {
-                "document": document,
+                "instance": document,
                 "id": id,
                 "filename": filename,
                 "data_url": data_url,
@@ -530,7 +531,7 @@ class DeleteDocument(CommandHandler):
         document = session.documents.fetch(id)
         document.new_deleted_version()
         result = session.documents.update(document)
-        session.notify(Events.DOCUMENT_DELETED, {"document": document, "id": id})
+        session.notify(Events.DOCUMENT_DELETED, {"instance": document, "id": id})
         return result
 
 

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -534,66 +534,135 @@ class DeleteDocument(CommandHandler):
         return result
 
 
-def log_change(data, session, now=utcnow, entity="", deleted=False):
+def log_change(data, session, now=utcnow, entity="", deleted=False, content_type=""):
+    def _get_content():
+        instance = None
+        for key in ["document", "bundle", "journal"]:
+            try:
+                instance = data[key]
+            except KeyError:
+                continue
+            else:
+                break
+
+        if instance is None:
+            return ""
+        else:
+            return instance.data()
+
     change = {"timestamp": now(), "entity": entity, "id": data["id"]}
 
     if deleted:
         change["deleted"] = True
 
+    content = _get_content()
+    if content:
+        change["content"] = content
+        change["content_type"] = content_type
+
     session.changes.add(change)
 
 
 DEFAULT_SUBSCRIBERS = [
-    (Events.DOCUMENT_REGISTERED, functools.partial(log_change, entity="Document")),
+    (
+        Events.DOCUMENT_REGISTERED,
+        functools.partial(log_change, entity="Document", content_type="text/xml"),
+    ),
     (
         Events.DOCUMENT_VERSION_REGISTERED,
-        functools.partial(log_change, entity="Document"),
+        functools.partial(log_change, entity="Document", content_type="text/xml"),
     ),
-    (Events.ASSET_VERSION_REGISTERED, functools.partial(log_change, entity="Document")),
+    (
+        Events.ASSET_VERSION_REGISTERED,
+        functools.partial(log_change, entity="Document", content_type="text/xml"),
+    ),
     (
         Events.DOCUMENTSBUNDLE_CREATED,
-        functools.partial(log_change, entity="DocumentsBundle"),
+        functools.partial(
+            log_change, entity="DocumentsBundle", content_type="application/json"
+        ),
     ),
     (
         Events.DOCUMENTSBUNDLE_METATADA_UPDATED,
-        functools.partial(log_change, entity="DocumentsBundle"),
+        functools.partial(
+            log_change, entity="DocumentsBundle", content_type="application/json"
+        ),
     ),
     (
         Events.DOCUMENT_ADDED_TO_DOCUMENTSBUNDLE,
-        functools.partial(log_change, entity="DocumentsBundle"),
+        functools.partial(
+            log_change, entity="DocumentsBundle", content_type="application/json"
+        ),
     ),
     (
         Events.DOCUMENT_INSERTED_TO_DOCUMENTSBUNDLE,
-        functools.partial(log_change, entity="DocumentsBundle"),
+        functools.partial(
+            log_change, entity="DocumentsBundle", content_type="application/json"
+        ),
     ),
-    (Events.JOURNAL_CREATED, functools.partial(log_change, entity="Journal")),
-    (Events.JOURNAL_METATADA_UPDATED, functools.partial(log_change, entity="Journal")),
-    (Events.ISSUE_ADDED_TO_JOURNAL, functools.partial(log_change, entity="Journal")),
-    (Events.ISSUE_INSERTED_TO_JOURNAL, functools.partial(log_change, entity="Journal")),
+    (
+        Events.JOURNAL_CREATED,
+        functools.partial(
+            log_change, entity="Journal", content_type="application/json"
+        ),
+    ),
+    (
+        Events.JOURNAL_METATADA_UPDATED,
+        functools.partial(
+            log_change, entity="Journal", content_type="application/json"
+        ),
+    ),
+    (
+        Events.ISSUE_ADDED_TO_JOURNAL,
+        functools.partial(
+            log_change, entity="Journal", content_type="application/json"
+        ),
+    ),
+    (
+        Events.ISSUE_INSERTED_TO_JOURNAL,
+        functools.partial(
+            log_change, entity="Journal", content_type="application/json"
+        ),
+    ),
     (
         Events.ISSUE_REMOVED_FROM_JOURNAL,
-        functools.partial(log_change, entity="Journal"),
+        functools.partial(
+            log_change, entity="Journal", content_type="application/json"
+        ),
     ),
     (
         Events.AHEAD_OF_PRINT_BUNDLE_SET_TO_JOURNAL,
-        functools.partial(log_change, entity="Journal"),
+        functools.partial(
+            log_change, entity="Journal", content_type="application/json"
+        ),
     ),
     (
         Events.AHEAD_OF_PRINT_BUNDLE_REMOVED_FROM_JOURNAL,
-        functools.partial(log_change, entity="Journal"),
+        functools.partial(
+            log_change, entity="Journal", content_type="application/json"
+        ),
     ),
     (
         Events.RENDITION_VERSION_REGISTERED,
-        functools.partial(log_change, entity="DocumentRendition"),
+        functools.partial(
+            log_change, entity="DocumentRendition", content_type="application/json"
+        ),
     ),
     (
         Events.DOCUMENT_DELETED,
         functools.partial(log_change, entity="Document", deleted=True),
     ),
-    (Events.JOURNAL_ISSUES_UPDATED, functools.partial(log_change, entity="Journal")),
+    (
+        Events.JOURNAL_ISSUES_UPDATED,
+        functools.partial(
+            log_change, entity="Journal", content_type="application/json"
+        ),
+    ),
     (
         Events.ISSUE_DOCUMENTS_UPDATED,
-        functools.partial(log_change, entity="DocumentsBundle"),
+        functools.partial(
+            log_change, entity="DocumentsBundle", content_type="application/json"
+        ),
     ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3 :: Only",
         "Operating System :: OS Independent",
     ],
-    entry_points={"paste.app_factory": ["main = documentstore.restfulapi:main"]},
+    entry_points={
+        "paste.app_factory": ["main = documentstore.restfulapi:main"],
+        "console_scripts": ["kernelctl = documentstore.kernelctl:main"],
+    },
 )

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -344,6 +344,37 @@ class ChangesStoreTestMixin:
 
         self.assertEqual(list(store.filter(limit=2)), changes[:2])
 
+    def test_fetch_by_id(self):
+        from bson.objectid import ObjectId
+
+        store = self.Store()
+
+        changes = [
+            {
+                "timestamp": "2018-08-05T23:03:44.971230Z",
+                "id": "0034-8910-rsp-48-2-0347",
+                "entity": "document",
+                "_id": ObjectId(),
+            },
+            {
+                "timestamp": "2018-08-05T23:03:47.891432Z",
+                "id": "0034-8910-rsp-48-2-0348",
+                "entity": "document",
+                "_id": ObjectId(),
+            },
+            {
+                "timestamp": "2018-08-05T23:06:47.621560Z",
+                "id": "0034-8910-rsp-48-2-0348",
+                "entity": "document",
+                "_id": ObjectId(),
+            },
+        ]
+
+        for change in changes:
+            store.add(change)
+
+        self.assertEqual(store.fetch(str(changes[1]["_id"])), changes[1])
+
 
 class InMemoryChangesStoreTest(ChangesStoreTestMixin, unittest.TestCase):
     Store = apptesting.InMemoryChangesDataStore

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -58,7 +58,7 @@ class CreateDocumentsBundleTest(CommandTestMixin, unittest.TestCase):
                     "id": "xpto",
                     "docs": [{"id": "/document/1"}],
                     "metadata": None,
-                    "bundle": mock.ANY,
+                    "instance": mock.ANY,
                 },
             )
 
@@ -179,7 +179,7 @@ class UpdateDocumentsBundleTest(CommandTestMixin, unittest.TestCase):
                 {
                     "id": "xpto",
                     "metadata": {"publication_year": "2019"},
-                    "bundle": mock.ANY,
+                    "instance": mock.ANY,
                 },
             )
 
@@ -223,7 +223,7 @@ class AddDocumentToDocumentsBundleTest(CommandTestMixin, unittest.TestCase):
             self.command(id="xpto", doc={"id": "/document/1"})
             mock_notify.assert_called_once_with(
                 self.event,
-                {"id": "xpto", "doc": {"id": "/document/1"}, "bundle": mock.ANY},
+                {"id": "xpto", "doc": {"id": "/document/1"}, "instance": mock.ANY},
             )
 
 
@@ -291,7 +291,7 @@ class InsertDocumentToDocumentsBundleTest(CommandTestMixin, unittest.TestCase):
                     "id": "xpto",
                     "doc": {"id": "/document/3"},
                     "index": 10,
-                    "bundle": mock.ANY,
+                    "instance": mock.ANY,
                 },
             )
 
@@ -362,7 +362,7 @@ class UpdateDocumentInDocumentsBundleTest(CommandTestMixin, unittest.TestCase):
                 mock_notify.assert_called_once_with(
                     self.event,
                     {
-                        "bundle": DocumentsBundleStub,
+                        "instance": DocumentsBundleStub,
                         "id": "issue-example-id",
                         "docs": [{"id": "a"}],
                     },
@@ -403,7 +403,7 @@ class CreateJournalTest(CommandTestMixin, unittest.TestCase):
         with mock.patch.object(self.session, "notify") as mock_notify:
             self.command(id="jxpto")
             mock_notify.assert_called_once_with(
-                self.event, {"id": "jxpto", "journal": mock.ANY, "metadata": None}
+                self.event, {"id": "jxpto", "instance": mock.ANY, "metadata": None}
             )
 
 
@@ -467,7 +467,7 @@ class AddIssueToJournalTest(CommandTestMixin, unittest.TestCase):
                 mock_notify.assert_called_once_with(
                     self.event,
                     {
-                        "journal": JournalStub,
+                        "instance": JournalStub,
                         "id": "0034-8910-rsp",
                         "issue": {"id": "0034-8910-rsp-48-2"},
                     },
@@ -563,7 +563,7 @@ class InsertIssueToJournalTest(CommandTestMixin, unittest.TestCase):
                 mock_notify.assert_called_once_with(
                     self.event,
                     {
-                        "journal": JournalStub,
+                        "instance": JournalStub,
                         "id": "0034-8910-rsp",
                         "index": 0,
                         "issue": {"id": "0034-8910-rsp-48-2"},
@@ -631,7 +631,7 @@ class RemoveIssueFromJournalTest(CommandTestMixin, unittest.TestCase):
                 mock_notify.assert_called_once_with(
                     self.event,
                     {
-                        "journal": JournalStub,
+                        "instance": JournalStub,
                         "id": "0034-8910-rsp",
                         "issue": "0034-8910-rsp-48-2",
                     },
@@ -704,7 +704,7 @@ class UpdateIssuesInJournalTest(CommandTestMixin, unittest.TestCase):
                 mock_notify.assert_called_once_with(
                     self.event,
                     {
-                        "journal": JournalStub,
+                        "instance": JournalStub,
                         "id": "journal-example-id",
                         "issues": [{"id": "a"}],
                     },
@@ -760,7 +760,7 @@ class SetAheadOfPrintBundleToJournalTest(CommandTestMixin, unittest.TestCase):
                 mock_notify.assert_called_once_with(
                     self.event,
                     {
-                        "journal": JournalStub,
+                        "instance": JournalStub,
                         "id": "0034-8910-rsp",
                         "aop": "0034-8910-rsp-aop",
                     },
@@ -809,7 +809,7 @@ class RemoveAheadOfPrintBundleFromJournalTest(CommandTestMixin, unittest.TestCas
             with mock.patch.object(self.session, "notify") as mock_notify:
                 self.command(id="0034-8910-rsp")
                 mock_notify.assert_called_once_with(
-                    self.event, {"journal": JournalStub, "id": "0034-8910-rsp"}
+                    self.event, {"instance": JournalStub, "id": "0034-8910-rsp"}
                 )
 
 
@@ -936,7 +936,7 @@ class UpdateJornalMetadataTest(CommandTestMixin, unittest.TestCase):
             self.command(id="1678-4596-cr", metadata=metadata)
             mock_notify.assert_called_once_with(
                 self.event,
-                {"id": "1678-4596-cr", "metadata": metadata, "journal": mock.ANY},
+                {"id": "1678-4596-cr", "metadata": metadata, "instance": mock.ANY},
             )
 
 
@@ -1016,7 +1016,7 @@ class RegisterRenditionVersionTest(CommandTestMixin, unittest.TestCase):
             mock_notify.assert_called_once_with(
                 self.event,
                 {
-                    "document": mock.ANY,
+                    "instance": mock.ANY,
                     "id": self.document.id(),
                     "filename": "0034-8910-rsp-48-2-0275-pt.pdf",
                     "data_url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-pt.pdf",
@@ -1132,5 +1132,5 @@ class DeleteDocumentTest(CommandTestMixin, unittest.TestCase):
         with mock.patch.object(self.session, "notify") as mock_notify:
             self.command(self.document.id())
             mock_notify.assert_called_once_with(
-                self.event, {"document": mock.ANY, "id": self.document.id()}
+                self.event, {"instance": mock.ANY, "id": self.document.id()}
             )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -10,7 +10,7 @@ from . import apptesting
 
 def make_services():
     session = apptesting.Session()
-    return services.get_handlers(lambda: session), session
+    return services.get_handlers(lambda: session, subscribers=[]), session
 
 
 class CommandTestMixin:


### PR DESCRIPTION
#### O que esse PR faz?

Faz com que o log de mudanças passe a armazenar um *snapshot* do dado modificado imediatamente após a realização da mudança. O dado que será feito o *snapshot* varia de acordo com o tipo de entidade: 

* Document: será armazenado o mesmo que é retornado pelo endpoint `/documents/:id` (XML codificado em UTF-8 com as URLs dos ativos interpoladas);
* Bundle: será armazenado o mesmo que é retornado pelo endpoint `/bundles/:id` (JSON)
* Journal: será armazenado o mesmo que é retornado pelo endpoint `/journals/:id` (JSON)

O conteúdo será compactado antes de ser armazenado no MongoDB, utilizando a função [`gzip.compress`](https://docs.python.org/3/library/gzip.html#gzip.compress).

Cada mudança retornada pelo endpoint `/changes` passa a ter o campo `change_id` que pode ser utilizada para obter o registro detalhado da mudança no endpoint `/changes/:change_id`. Neste registro detalhado é possível recuperar o *snapshot* do dado modificado. Exemplo:

```python
import requests, gzip, base64
response = requests.get('http://0.0.0.0:6543/changes/5d9c8cce699ab206c760e2dc').json()
print(gzip.decompress(base64.b64decode(response["content_gz_b64"])))
```

Além disso, também foi incluído um utilitário de linha de comando para auxiliar em tarefas administrativas de manutenção da instância. A motivação para a criação do utilitário foi de operar a criação de índices no banco de dados, e este é o único comando implementado até o momento.

#### Onde a revisão poderia começar?

Sugiro seguir os commits na ordem em que foram criados. Eu me esforcei para fazer de forma a ser fácil de seguir.

Foi mal gente, este PR acabou ficando maior do que o esperado. 

#### Como este poderia ser testado manualmente?

1. Suba uma instância da aplicação com o banco de dados em branco
2. Crie os índices: `kernelctl create-indexes mongodb://localhost:27017`
3. Registre um novo documento: 
```
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347 -d '{"data": "https://raw.githubusercontent.com/scieloorg/packtools/master/tests/samples/0034-8910-rsp-48-2-0347.xml", "assets": [{"asset_id":"0034-8910-rsp-48-2-0347-gf01", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf01-en", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf02", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf02-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf03", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf03.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf03-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf03-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf04", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf04.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf04-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf04-en.jpg"}]}'
```
4. Acesse a API de mudanças: `/changes`
5. Copie o identificador de uma mudança e veja seus detalhes: `/changes/:id`

#### Algum cenário de contexto que queira dar?

Esta mudança torna mais poderoso o controle de versão e possibilita funcionalidades de auditoria para todos os tipos de entidade mantidos pela aplicação.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
