### PR TITLE
Atualiza a integração com Sentry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apk add --no-cache --virtual .build-deps \
         make gcc libxml2-dev libxslt-dev musl-dev g++ \
     && apk add libxml2 libxslt \
     && pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir raven \
     && pip install --no-cache-dir -r requirements.txt \
     && pip install --no-index --find-links=file:///deps -U scielo-kernel \
     && apk --purge del .build-deps \

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ kernel.app.mongodb.replicaset     | KERNEL_APP_MONGODB_REPLICASET     |
 kernel.app.mongodb.readpreference | KERNEL_APP_MONGODB_READPREFERENCE | secondaryPreferred
 kernel.app.prometheus.enabled     | KERNEL_APP_PROMETHEUS_ENABLED     | True
 kernel.app.prometheus.port        | KERNEL_APP_PROMETHEUS_PORT        | 8087
+kernel.app.sentry.enabled         | KERNEL_APP_SENTRY_ENABLED         | False 
+kernel.app.sentry.dsn             | KERNEL_APP_SENTRY_DSN             | 
+kernel.app.sentry.environment     | KERNEL_APP_SENTRY_ENVIRONMENT     | 
 
 
 A configuração padrão assume o uso de uma instância *standalone* do MongoDB. Para

--- a/development.ini
+++ b/development.ini
@@ -13,6 +13,9 @@ kernel.app.mongodb.dsn=mongodb://localhost:27017
 ;kernel.app.mongodb.readpreference=
 ;kernel.app.prometheus.enabled=
 ;kernel.app.prometheus.port=
+;kernel.app.sentry.enabled=
+;kernel.app.sentry.dsn=
+;kernel.app.sentry.environment=
 
 [server:main]
 use = egg:waitress#main

--- a/production.ini
+++ b/production.ini
@@ -25,41 +25,28 @@ port = 6543
 # Begin logging configuration
 
 [loggers]
-keys = root, documentstore, sentry
+keys = root, documentstore
 
 [handlers]
-keys = console, sentry
+keys = console
 
 [formatters]
 keys = generic
 
 [logger_root]
 level = ERROR
-handlers = console, sentry
+handlers = console
 
 [logger_documentstore]
 level = INFO
-handlers = console, sentry
-qualname = documentstore
-propagate = 0
-
-[logger_sentry]
-level = WARN
 handlers = console
-qualname = sentry.errors
+qualname = documentstore
 propagate = 0
 
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
-formatter = generic
-
-[handler_sentry]
-class = raven.handlers.logging.SentryHandler
-# a variavel de ambiente SENTRY_DSN ira sobrescrever o valor da diretiva args.
-args = ()
-level = WARNING
 formatter = generic
 
 [formatter_generic]

--- a/production.ini
+++ b/production.ini
@@ -8,11 +8,14 @@ pyramid.debug_routematch = false
 pyramid.debug_templates = false
 pyramid.default_locale_name = en
 
-;kernel.app.mongodb.dsn =
+;kernel.app.mongodb.dsn=
 ;kernel.app.mongodb.replicaset=
 ;kernel.app.mongodb.readpreference=
 ;kernel.app.prometheus.enabled=
 ;kernel.app.prometheus.port=
+;kernel.app.sentry.enabled=
+;kernel.app.sentry.dsn=
+;kernel.app.sentry.environment=
 
 [server:main]
 use = egg:waitress#main

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ regex==2018.8.29
 repoze.lru==0.7
 requests==2.22.0
 scielo-clea==0.4.0
+sentry-sdk==0.12.3
 simplejson==3.16.0
 six==1.11.0
 translationstring==1.3

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
         "scielo-clea>=0.3.0",
         "waitress",
         "prometheus_client",
+        "sentry-sdk",
     ],
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
#### O que esse PR faz?
Anteriormente a integração era feita por meio da biblioteca `raven` que teve seu desenvolvimento descontinuado a mais de ano em favor da nova `sentry-sdk`. Este pull-request visa a atualização da integração.

#### Onde a revisão poderia começar?

Acredito que pelas diretivas de configuração que foram expostas, que são 3:

- Uma que permite que a integração seja ligada/desligada;
- O DSN da instância no Sentry; e
- Uma string que identifica o ambiente da instância, por exemplo _dev_, _homolog_ ou _prod_.

#### Como este poderia ser testado manualmente?

Será necessário subir localmente uma instância do Sentry e provocar uma exceção, por exemplo incluindo a expressão `1/0` no código de alguma _view-function_.

#### Algum cenário de contexto que queira dar?

Sentry faz parte das ferramentas de monitoramento utilizadas pela equipe de infraestrutura e desenvolvimento do SciELO. A integração é importante para as operações diárias.

#### Tickets relacionados

#192