### PR TITLE
Adiciona o PID no DocumentsBundle.

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -768,6 +768,15 @@ class DocumentsBundle:
         self.manifest = BundleManifest.set_metadata(self._manifest, "volume", _value)
 
     @property
+    def pid(self):
+        return BundleManifest.get_metadata(self.manifest, "pid")
+
+    @pid.setter
+    def pid(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(self._manifest, "pid", _value)
+
+    @property
     def number(self):
         return BundleManifest.get_metadata(self.manifest, "number")
 

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -251,6 +251,7 @@ class DocumentsBundleSchema(colander.MappingSchema):
     supplement = colander.SchemaNode(colander.String(), missing=colander.drop)
     volume = colander.SchemaNode(colander.String(), missing=colander.drop)
     number = colander.SchemaNode(colander.String(), missing=colander.drop)
+    pid = colander.SchemaNode(colander.String(), missing=colander.drop)
 
     @colander.instantiate(missing=colander.drop)
     class titles(colander.SequenceSchema):
@@ -1138,7 +1139,7 @@ class PlainTextRenderer:
 
 def split_dsn(dsns):
     """Produz uma lista de DSNs a partir de uma string separada de DSNs separados
-    por espaços ou quebras de linha. A escolha dos separadores se baseia nas 
+    por espaços ou quebras de linha. A escolha dos separadores se baseia nas
     convenções do framework Pyramid.
     """
     return [dsn.strip() for dsn in str(dsns).split() if dsn]

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -161,6 +161,7 @@ def documents_bundle_registry_data_fixture():
         "supplement": "1",
         "volume": "1",
         "number": "1",
+        "pid": "0102-330620190001",
         "publication_months": {"month": 1},
         "titles": [
             {

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -901,6 +901,19 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
             [("2018-08-05T22:33:49.795151Z", "2018")],
         )
 
+    def test_pid_is_empty_str(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(documents_bundle.pid, "")
+
+    def test_set_pid(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        documents_bundle.pid = "1413-785220180001"
+        self.assertEqual(documents_bundle.pid, "1413-785220180001")
+        self.assertEqual(
+            documents_bundle.manifest["metadata"]["pid"],
+            [("2018-08-05T22:33:49.795151Z", "1413-785220180001")],
+        )
+
     def test_set_publication_year_convert_to_str(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
         documents_bundle.publication_year = 2018


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona o **PID** no DocumentsBundle.

#### Onde a revisão poderia começar?

- documentstore/domain.py
- documentstore/restfulapi.py
- tests/test_restfulapi.py
- tests/apptesting.py


#### Como este poderia ser testado manualmente?

É possível realizar um teste manual criando ou atualizando um **bundle**, vejam: 

**Criando** um bundle: 

```
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/0066-782X-1999-v72-n0 -d '{"publication_year": "1999", "pid": "0102-330620190002"}' -v
```

**Atualizando** um bundle existente: 

```
curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/0066-782X-1999-v72-n0 -d '{"publication_year": "1999", "pid": "0102-330620190002"}' -v
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

Tela com o teste manual realizado antes de enviar o PR:

<img width="920" alt="Screen Shot 2019-12-18 at 14 58 34" src="https://user-images.githubusercontent.com/373745/71110872-e6483100-21a6-11ea-8bc8-6e0e42f2c8cc.png">

#### Quais são tickets relevantes?
https://github.com/scieloorg/kernel/issues/205

### Referências
N/A
