### PR TITLE
Simplifica o schema de metadata para o BundleManifest

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -567,17 +567,15 @@ class BundleManifest:
         now: Callable[[], str] = utcnow,
     ) -> dict:
         _bundle = deepcopy(bundle)
-        _now = now()
-        metadata = _bundle["metadata"].setdefault(name, [])
-        metadata.append((_now, value))
-        _bundle["updated"] = _now
+        _bundle["metadata"][name] = value
+        _bundle["updated"] = now()
         return _bundle
 
     @staticmethod
     def get_metadata(bundle: dict, name: str, default="") -> Any:
         try:
-            return bundle["metadata"].get(name, [])[-1][1]
-        except IndexError:
+            return bundle["metadata"][name]
+        except KeyError:
             return default
 
     @staticmethod
@@ -705,11 +703,7 @@ class DocumentsBundle:
         return self.manifest.get("id", "")
 
     def data(self):
-        _manifest = self.manifest
-        _manifest["metadata"] = {
-            attr: value[-1][-1] for attr, value in _manifest["metadata"].items()
-        }
-        return _manifest
+        return self.manifest
 
     def data_bytes(self) -> bytes:
         """Retorna `self.data()` codificado em utf-8.
@@ -855,14 +849,8 @@ class Journal:
         self._manifest = value
 
     def data(self):
-        """Retorna o manifesto completo de um Journal com os
-        metadados em sua última versão"""
-        _manifest = self.manifest
-
-        for key, value in _manifest["metadata"].items():
-            _manifest["metadata"][key] = value[-1][-1]
-
-        return _manifest
+        """Retorna o manifesto completo de um Journal"""
+        return self.manifest
 
     def data_bytes(self) -> bytes:
         """Retorna `self.data()` codificado em utf-8.

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -573,10 +573,7 @@ class BundleManifest:
 
     @staticmethod
     def get_metadata(bundle: dict, name: str, default="") -> Any:
-        try:
-            return bundle["metadata"][name]
-        except KeyError:
-            return default
+        return bundle["metadata"].get(name, default)
 
     @staticmethod
     def get_metadata_all(bundle: dict, name: str) -> Any:


### PR DESCRIPTION
#### O que esse PR faz?

Simplifica o manifesto do `BundleManifest`. A partir deste PR o modo de versionamento `append-only` foi removido e o manifesto passa a operar de fato como `chave->valor`.

#### Onde a revisão poderia começar?
- `documentstore/domain.py` L:`569`

#### Como este poderia ser testado manualmente?
Para testar este PR manualmente, deve-se:
- Executar o `kernel`;
- Registrar um `journal`:
  -  ex: `curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX -d '{"title": "Exemplo de journal"}'`
- Atualizar o `journal` recém criado:
  - ex: `curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX -d '{"title": "Título modificado"}'`
- Verifique a partir do banco de dados que o histórico da chave `metadata` não é mais guardado na coleção `journal`.

#### Algum cenário de contexto que queira dar?
Esta modificação visa concentrar a responsabilidade de armazenamento de mudanças em um único local. Também remove a duplicidade de histórico e por consequência economiza no armazenamento de dados. 

### Screenshots
N/A

#### Quais são tickets relevantes?
#194 

### Referências
N/A
