### PR TITLE
Modifica o status_history do domínio Journal para aceitar uma lista de mudanças

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -941,18 +941,21 @@ class Journal:
         )
 
     @property
-    def status(self):
-        return BundleManifest.get_metadata(self.manifest, "status", {})
+    def status_history(self):
+        return BundleManifest.get_metadata(self.manifest, "status_history", [])
 
-    @status.setter
-    def status(self, value: dict):
+    @status_history.setter
+    def status_history(self, value: list):
         try:
-            value = dict(value)
+            _value = [dict(status) for status in list(value)]
         except (TypeError, ValueError):
             raise TypeError(
-                "cannot set status with value " '"%s": value must be dict' % repr(value)
+                "cannot set status_history with value "
+                '"%s": value must be a list of dict' % repr(value)
             ) from None
-        self.manifest = BundleManifest.set_metadata(self._manifest, "status", value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "status_history", _value
+        )
 
     @property
     def subject_areas(self):
@@ -1086,10 +1089,6 @@ class Journal:
         self.manifest = BundleManifest.set_metadata(
             self._manifest, "previous_journal", value
         )
-
-    @property
-    def status_history(self):
-        return BundleManifest.get_metadata_all(self.manifest, "status")
 
     @property
     def contact(self) -> dict:

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -178,9 +178,12 @@ class JournalSchema(colander.MappingSchema):
     scielo_issn = colander.SchemaNode(colander.String(), missing=colander.drop)
     print_issn = colander.SchemaNode(colander.String(), missing=colander.drop)
     electronic_issn = colander.SchemaNode(colander.String(), missing=colander.drop)
-    status = colander.SchemaNode(
-        colander.Mapping(unknown="preserve"), missing=colander.drop
-    )
+
+    @colander.instantiate(missing=colander.drop)
+    class status_history(colander.SequenceSchema):
+        status = colander.SchemaNode(
+            colander.Mapping(unknown="preserve"), missing=colander.drop
+        )
 
     @colander.instantiate(missing=colander.drop)
     class subject_areas(colander.SequenceSchema):

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1315,16 +1315,16 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             journal.manifest["metadata"]["electronic_issn"], "1809-4392",
         )
 
-    def test_status_is_empty_str(self):
+    def test_status_is_empty_list(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
-        self.assertEqual(journal.status, {})
+        self.assertEqual(journal.status_history, [])
 
     def test_set_status(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
-        journal.status = {"status": "current"}
-        self.assertEqual(journal.status, {"status": "current"})
+        journal.status_history = [{"status": "current"}]
+        self.assertEqual(journal.status_history, [{"status": "current"}])
         self.assertEqual(
-            journal.manifest["metadata"]["status"], {"status": "current"},
+            journal.manifest["metadata"]["status_history"], [{"status": "current"}],
         )
 
     def test_get_created(self):
@@ -1720,16 +1720,16 @@ class JournalTest(UnittestMixin, unittest.TestCase):
 
     def test_status_history(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
-        journal.status = {"status": "CURRENT"}
-        self.assertEqual(journal.status_history, {"status": "CURRENT"})
+        journal.status_history = [{"status": "CURRENT"}]
+        self.assertEqual(journal.status_history, [{"status": "CURRENT"}])
 
-        journal.status = {"status": "SUSPENDED", "notes": "motivo"}
+        journal.status_history = [{"status": "SUSPENDED", "notes": "motivo"}]
         self.assertEqual(
-            journal.status_history, {"status": "SUSPENDED", "notes": "motivo"}
+            journal.status_history, [{"status": "SUSPENDED", "notes": "motivo"}]
         )
 
-        journal.status = {"status": "CEASED"}
-        self.assertEqual(journal.status_history, {"status": "CEASED"})
+        journal.status_history = [{"status": "CEASED"}]
+        self.assertEqual(journal.status_history, [{"status": "CEASED"}])
 
     def test_contact_is_empty_list(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request modifica o domínio do `Journal` para que agora seja possível guardar uma lista com o histórico de modificações (suspensão/paralisação/etc) de um periódico. Esta semântica em específico para este campo nos permite migrar as coleções sem que seja necessário criar `1...N` versões do mesmo periódico apenas para preservar todo o histórico de mudanças (não confundir com mudanças no Kernel).

Este PR também facilita a sincronização dos periódicos pelo airflow, não será mais necessário selecionar sempre o último status da lista de status. Isso garante que não haja perda de conteúdo, exemplo:
- A DAG de espelhamento foi executada às 12:00;
- O registro do periódico `X` é modificado 5 vezes, seja qual for o motivo para isso entre 12:00 e 13:00.
- Quando a próxima execução acontecer, todos os históricos serão enviados (não mais apenas o último);

#### Onde a revisão poderia começar?

- `documentstore/domain.py` L: `944`

#### Como este poderia ser testado manualmente?
- Cadastre um novo periódico com:
   - `curl -X PUT -H 'Accept: application/json' -H 'Content-type: application/json' http://0.0.0.0:6543/journals/teste -d '{ "status_history": [{"status": "current", "date": "2020-01-01T00:00:00.000000Z"}]}'`
- Verifique seu conteúdo com:
   - `curl -H 'Accept: application/json' -H 'Content-type: application/json' http://0.0.0.0:6543/journals/teste`
- Observe a lista de histórico;
- Atualize o status do periódico com:
   - `curl -X PATCH -H 'Accept: application/json' -H 'Content-type: application/json' http://0.0.0.0:6543/journals/teste -d '{ "status_history": [{"status": "current", "date": "2020-01-01T00:00:00.000000Z"}, {"status": "SUSPENDED", "date": "2020-01-02T00:00:00.000000Z", "notes": "something happened"}]}'`
- Verifique seu conteúdo com:
   - `curl -H 'Accept: application/json' -H 'Content-type: application/json' http://0.0.0.0:6543/journals/teste`
- Observe que agora o periódico possui os seus dois status devidamente armazenados.

#### Algum cenário de contexto que queira dar?

N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/opac-airflow/issues/174

### Referências
N/A
