### PR TITLE
Corrige bug na atualização de docs de bundles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(setup_path, "README.md")) as readme:
 
 setuptools.setup(
     name="scielo-kernel",
-    version="0.1rc8",
+    version="0.1rc9",
     author="SciELO Dev Team",
     author_email="scielo-dev@googlegroups.com",
     description="Kernel é o componente central da nova arquitetura de sistemas "

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -161,7 +161,7 @@ class FetchDocumentsBundleTest(unittest.TestCase):
         self.config.add_route("bundles", pattern="/bundles/{bundle_id}")
 
     def test_fetch_documents_bundle_raises_bad_request_if_bundle_id_is_not_informed(
-        self
+        self,
     ):
         response = restfulapi.fetch_documents_bundle(self.request)
         self.assertIsInstance(response, HTTPBadRequest)
@@ -324,7 +324,7 @@ class PutDocumentsBundleDocumentTest(unittest.TestCase):
 
     def test_should_call_update_documents_in_issues(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = [{"id": "doc-1"}, {"id": "doc-2"}]
+        self.request.validated = {"body": [{"id": "doc-1"}, {"id": "doc-2"}]}
         MockUpdateDocumentsInIssues = Mock()
         self.request.services[
             "update_documents_in_documents_bundle"
@@ -336,20 +336,20 @@ class PutDocumentsBundleDocumentTest(unittest.TestCase):
 
     def test_should_return_422_if_already_exists_exception_is_raised(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = [{"id": "doc-1"}, {"id": "doc-1"}]
+        self.request.validated = {"body": [{"id": "doc-1"}, {"id": "doc-1"}]}
         response = restfulapi.put_bundles_documents(self.request)
         self.assertIsInstance(response, HTTPUnprocessableEntity)
 
     def test_should_not_update_if_already_exists_exception_is_raised(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = [{"id": "doc-1"}, {"id": "doc-1"}]
+        self.request.validated = {"body": [{"id": "doc-1"}, {"id": "doc-1"}]}
         restfulapi.put_bundles_documents(self.request)
         response = restfulapi.fetch_documents_bundle(self.request)
         self.assertEqual([], response.get("items"))
 
     def test_should_return_404_if_bundle_not_found(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = [{"id": "doc-1"}]
+        self.request.validated = {"body": [{"id": "doc-1"}]}
         MockUpdateDocumentsInIssues = Mock(
             side_effect=exceptions.DoesNotExist("Does Not Exist")
         )
@@ -361,7 +361,7 @@ class PutDocumentsBundleDocumentTest(unittest.TestCase):
 
     def test_should_return_204_if_bundle_issues_was_updated(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = [{"id": "doc-1"}]
+        self.request.validated = {"body": [{"id": "doc-1"}]}
         response = restfulapi.put_bundles_documents(self.request)
         self.assertIsInstance(response, HTTPNoContent)
 

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -674,10 +674,12 @@ class PutJournalIssuesTest(unittest.TestCase):
 
     def test_should_call_update_issues_in_journal(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = [
-            {"id": "issue-1", "year": "2019"},
-            {"id": "issue-2", "year": "2019"},
-        ]
+        self.request.validated = {
+            "body": [
+                {"id": "issue-1", "year": "2019"},
+                {"id": "issue-2", "year": "2019"},
+            ],
+        }
         MockUpdateIssuesInJournal = Mock()
         self.request.services["update_issues_in_journal"] = MockUpdateIssuesInJournal
         restfulapi.put_journal_issues(self.request)
@@ -691,26 +693,30 @@ class PutJournalIssuesTest(unittest.TestCase):
 
     def test_should_return_422_if_already_exists_exception_is_raised(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = [
-            {"id": "issue-1", "year": "2019"},
-            {"id": "issue-1", "year": "2019"},
-        ]
+        self.request.validated = {
+            "body": [
+                {"id": "issue-1", "year": "2019"},
+                {"id": "issue-1", "year": "2019"},
+            ],
+        }
         response = restfulapi.put_journal_issues(self.request)
         self.assertIsInstance(response, HTTPUnprocessableEntity)
 
     def test_should_not_update_if_already_exists_exception_is_raised(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = [
-            {"id": "issue-1", "year": "2019"},
-            {"id": "issue-1", "year": "2019"},
-        ]
+        self.request.validated = {
+            "body": [
+                {"id": "issue-1", "year": "2019"},
+                {"id": "issue-1", "year": "2019"},
+            ],
+        }
         restfulapi.put_journal_issues(self.request)
         response = restfulapi.get_journal(self.request)
         self.assertEqual([], response.get("items"))
 
     def test_should_return_404_if_journal_not_found(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = [{"id": "issue-1", "year": "2019"}]
+        self.request.validated = {"body": [{"id": "issue-1", "year": "2019"}]}
         MockUpdateIssuesInJournal = Mock(
             side_effect=exceptions.DoesNotExist("Does Not Exist")
         )
@@ -720,7 +726,7 @@ class PutJournalIssuesTest(unittest.TestCase):
 
     def test_should_return_204_if_journal_issues_was_updated(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = [{"id": "issue-1", "year": "2019"}]
+        self.request.validated = {"body": [{"id": "issue-1", "year": "2019"}]}
         response = restfulapi.put_journal_issues(self.request)
         self.assertIsInstance(response, HTTPNoContent)
 


### PR DESCRIPTION
Resolve bug, introduzido com a atualização da lib Cornice para sua versão 4, que impedia o funcionamento do _endpoint_ 
`/bundles/:bundle_id/documents`.

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
1. Inicie uma instância local do Kernel. 
2. Registre um _bundle_: `curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/0034-8910-rsp-48-2 -d '{"publication_year": "1999", "pid": "0102-330620190002"}'`
3. Registre a referência a um _document_ no _bundle_: `curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/0034-8910-rsp-48-2/documents -d '[{"id": "xfxKrk3RxLGjS9sWxY9LgLH", "order": "0003"}]'`
4. Observe que os dados foram cadastrados: `curl http://0.0.0.0:6543/bundles/0034-8910-rsp-48-2`

#### Algum cenário de contexto que queira dar?
Você deve ter percebido a ausência de testes automatizados, e isso se justifica na atual falta de infraestrutura para testar essas validações do Cornice com Colander. Para resolvermos isso teríamos que passar a fazer testes mais compreensivos, usando o [_WebTest_](https://docs.pylonsproject.org/projects/webtest/en/latest/) por exemplo.

### Screenshots
n/a

#### Quais são tickets relevantes?
#221 

### Referências
  * https://cornice.readthedocs.io/en/latest/upgrading.html?highlight=colander_validator#x-to-4-x
  * https://cornice.readthedocs.io/en/latest/upgrading.html?highlight=colander_validator#complex-colander-validation
