### PR TITLE
Adiciona diretiva para o write-concern do MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ kernel.app.mongodb.dsn            | KERNEL_APP_MONGODB_DSN            | mongodb:
 kernel.app.mongodb.dbname         | KERNEL_APP_MONGODB_DBNAME         | document-store
 kernel.app.mongodb.replicaset     | KERNEL_APP_MONGODB_REPLICASET     |
 kernel.app.mongodb.readpreference | KERNEL_APP_MONGODB_READPREFERENCE | secondaryPreferred
+kernel.app.mongodb.writeto        | KERNEL_APP_MONGODB_WRITETO        | 1
 kernel.app.prometheus.enabled     | KERNEL_APP_PROMETHEUS_ENABLED     | True
 kernel.app.prometheus.port        | KERNEL_APP_PROMETHEUS_PORT        | 8087
 kernel.app.sentry.enabled         | KERNEL_APP_SENTRY_ENABLED         | False 

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -1186,6 +1186,7 @@ DEFAULT_SETTINGS = [
         str,
         "secondaryPreferred",
     ),
+    ("kernel.app.mongodb.writeto", "KERNEL_APP_MONGODB_WRITETO", int, 1),
     ("kernel.app.mongodb.dbname", "KERNEL_APP_MONGODB_DBNAME", str, "document-store"),
     ("kernel.app.prometheus.enabled", "KERNEL_APP_PROMETHEUS_ENABLED", asbool, True),
     ("kernel.app.prometheus.port", "KERNEL_APP_PROMETHEUS_PORT", int, 8087),
@@ -1235,6 +1236,7 @@ def main(global_config, **settings):
         options={
             "replicaSet": settings["kernel.app.mongodb.replicaset"],
             "readPreference": settings["kernel.app.mongodb.readpreference"],
+            "w": settings["kernel.app.mongodb.writeto"],
         },
     )
     Session = adapters.Session.partial(mongo)


### PR DESCRIPTION
Torna possível configurar o argumento `w` do [_write concern_](https://docs.mongodb.com/manual/reference/write-concern/) do MongoDB.

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
n/a

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#195 

### Referências
* https://docs.mongodb.com/manual/reference/write-concern/
