### PR TITLE
Retornar no front, metadados (por  hora apenas título de artigo) com a "formatação" mantida 

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -279,9 +279,9 @@ def display_format(
     parser = DEFAULT_XMLPARSER
     xml = etree.parse(BytesIO(data), parser)
     xpaths = [
-        ("article-title", ".", ".//article-meta//article-title"),
-        ("article-title", ".//article-meta//trans-title-group", ".//trans-title"),
-        ("article-title", ".//sub-article", ".//front-stub//article-title"),
+        ("article_title", ".", ".//article-meta//article-title"),
+        ("article_title", ".//article-meta//trans-title-group", ".//trans-title"),
+        ("article_title", ".//sub-article", ".//front-stub//article-title"),
     ]
 
     for label, lang_xpath, content_xpath in xpaths:

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -266,6 +266,15 @@ def assets_from_remote_xml(
 def display_format(
     data: bytes,
 ) -> dict:
+    """
+    (#PCDATA | email | ext-link | uri | inline-supplementary-material |
+     related-article | related-object | bold | fixed-case | italic | 
+     monospace | overline | roman | sans-serif | sc | strike | underline | 
+     ruby | alternatives | inline-graphic | inline-media | private-char | 
+     chem-struct | inline-formula | tex-math | mml:math | abbrev | index-term | 
+     index-term-range-end | milestone-end | milestone-start | named-content | 
+     styled-content | fn | target | xref | sub | sup | break)*
+    """
     metadata = {}
     parser = DEFAULT_XMLPARSER
     xml = etree.parse(BytesIO(data), parser)
@@ -280,6 +289,7 @@ def display_format(
             lang = lang_node.get('{http://www.w3.org/XML/1998/namespace}lang')
             for content_node in lang_node.findall(content_xpath):
                 _display_format_remove_xref(content_node)
+                _display_format_convert_bold_and_italic(content_node)
                 content = _display_format_get_content(content_node)
                 if content and lang:
                     _display_format_update_output(
@@ -304,6 +314,13 @@ def _display_format_remove_xref(node):
     for xref in node.findall(".//xref"):
         p = xref.getparent()
         p.remove(xref)
+
+
+def _display_format_convert_bold_and_italic(node):
+    for tag in ("bold", "italic"):
+        for found in node.findall(".//{}".format(tag)):
+            found.tag = tag[0]
+
 
 
 class Document:

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -258,7 +258,7 @@ class SanitizeDocumentFront(CommandHandler):
         return {
             **clea_article.data_full,
             "aff_contrib_full": clea_join.aff_contrib_full(clea_article),
-            "display-format": display_format(xml_data),
+            "display_format": display_format(xml_data),
         }
 
 

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -10,6 +10,7 @@ from clea import join as clea_join, core as clea_core
 
 from .interfaces import Session
 from .domain import Document, DocumentsBundle, Journal, utcnow
+from .domain import display_format
 from .exceptions import DoesNotExist, AlreadyExists, VersionAlreadySet
 
 __all__ = ["get_handlers"]
@@ -257,6 +258,7 @@ class SanitizeDocumentFront(CommandHandler):
         return {
             **clea_article.data_full,
             "aff_contrib_full": clea_join.aff_contrib_full(clea_article),
+            "display-format": display_format(xml_data),
         }
 
 

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -2000,7 +2000,7 @@ class MetadataWithStylesForArticleWithTransTitlesTests(unittest.TestCase):
     def test_display_format(self):
         result = domain.display_format(self.xml)
         expected = {
-            "article-title": {
+            "article_title": {
                 "pt": 
                     ('Uma Reflexão de Professores sobre Demonstrações '
                         'Relativas à Irracionalidade de '
@@ -2060,7 +2060,7 @@ class MetadataWithStylesForArticleWithSubarticlesTests(unittest.TestCase):
     def test_display_format_removes_xref(self):
         result = domain.display_format(self.xml)
         expected = {
-            "article-title": {
+            "article_title": {
                 "en": (
                     """Heparin solution in the prevention of occlusions """
                     """in Hickman<sup>®</sup> catheters a randomized """

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1974,3 +1974,106 @@ class RetryGracefullyDecoratorTests(unittest.TestCase):
 
         calls = [mock.call(1.2 ** i) for i in range(1, 3)]
         retry_gracefully._sleep.assert_has_calls(calls)
+
+
+class MetadataWithStylesForArticleWithTransTitlesTests(unittest.TestCase):
+
+    def setUp(self):
+        self.xml = (
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">'
+            '<front>'
+            '<article-meta>'
+            '''<title-group>
+                <article-title>Uma Reflexão de Professores sobre Demonstrações Relativas à Irracionalidade de <inline-formula><mml:math display="inline" id="m1"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt></mml:mrow></mml:math></inline-formula> </article-title>
+                <trans-title-group xml:lang="en">
+                  <trans-title>Teachers' Considerations on the Irrationality Proof of <inline-formula><mml:math display="inline" id="m2"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt></mml:mrow></mml:math></inline-formula> </trans-title>
+                </trans-title-group>
+                <trans-title-group xml:lang="es">
+                  <trans-title>Español <inline-formula><mml:math display="inline" id="m2"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt></mml:mrow></mml:math></inline-formula> </trans-title>
+                </trans-title-group>
+            </title-group>'''
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        ).encode("utf-8")
+
+    def test_display_format(self):
+        result = domain.display_format(self.xml)
+        expected = {
+            "article-title": {
+                "pt": 
+                    ('Uma Reflexão de Professores sobre Demonstrações '
+                        'Relativas à Irracionalidade de '
+                        '<inline-formula><mml:math display="inline" id="m1">'
+                        '<mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt>'
+                        '</mml:mrow></mml:math></inline-formula> '),
+                "en": (
+                    """Teachers' Considerations on the Irrationality Proof """
+                    """of <inline-formula><mml:math display="inline" """
+                    """id="m2">"""
+                    """<mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt>"""
+                    """</mml:mrow></mml:math></inline-formula> """),
+                "es": (
+                    """Español <inline-formula><mml:math display="inline" """
+                    """id="m2"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn>"""
+                    """</mml:msqrt></mml:mrow></mml:math></inline-formula> """
+                    ),
+            }
+        }
+        self.assertEqual(expected, result)
+
+
+class MetadataWithStylesForArticleWithSubarticlesTests(unittest.TestCase):
+
+    def setUp(self):
+        self.xml = (
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '''
+            <title-group>
+                <article-title>Heparin solution in the prevention of occlusions in Hickman<sup>®</sup> catheters a randomized clinical trial<xref ref-type="fn" rid="fn1">*</xref></article-title>
+            </title-group>
+            '''
+            '</article-meta>'
+            '</front>'
+
+            '''
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                  <title-group>
+                    <article-title>Solução de heparina na prevenção de oclusão do Cateter de Hickman<sup>®</sup> ensaio clínico randomizado<xref ref-type="fn" rid="fn2">*</xref></article-title>
+                  </title-group>
+              </front-stub>
+            </sub-article>
+            <sub-article article-type="translation" id="s2" xml:lang="es">
+                <front-stub>
+                  <title-group>
+                    <article-title>Solución de heparina para prevenir oclusiones en catéteres de Hickman<sup>®</sup> un ensayo clínico aleatorizado<xref ref-type="fn" rid="fn3">*</xref></article-title>
+                  </title-group>
+                </front-stub>
+            </sub-article>
+            '''
+            '</article>'
+        ).encode("utf-8")
+
+    def test_display_format_removes_xref(self):
+        result = domain.display_format(self.xml)
+        expected = {
+            "article-title": {
+                "en": (
+                    """Heparin solution in the prevention of occlusions """
+                    """in Hickman<sup>®</sup> catheters a randomized """
+                    """clinical trial"""
+                    ),
+                "pt": (
+                    """Solução de heparina na prevenção de oclusão do """
+                    """Cateter de Hickman<sup>®</sup> ensaio clínico """
+                    """randomizado"""),
+                "es": (
+                    """Solución de heparina para prevenir oclusiones en """
+                    """catéteres de Hickman<sup>®</sup> un ensayo clínico """
+                    """aleatorizado"""),
+            }
+        }
+        self.assertDictEqual(expected, result)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -2042,14 +2042,14 @@ class MetadataWithStylesForArticleWithSubarticlesTests(unittest.TestCase):
             <sub-article article-type="translation" id="s1" xml:lang="pt">
                 <front-stub>
                   <title-group>
-                    <article-title>Solução de heparina na prevenção de oclusão do Cateter de Hickman<sup>®</sup> ensaio clínico randomizado<xref ref-type="fn" rid="fn2">*</xref></article-title>
+                    <article-title>Solução de <bold>heparina</bold> na prevenção de oclusão do Cateter de Hickman<sup>®</sup> ensaio clínico randomizado<xref ref-type="fn" rid="fn2">*</xref></article-title>
                   </title-group>
               </front-stub>
             </sub-article>
             <sub-article article-type="translation" id="s2" xml:lang="es">
                 <front-stub>
                   <title-group>
-                    <article-title>Solución de heparina para prevenir oclusiones en catéteres de Hickman<sup>®</sup> un ensayo clínico aleatorizado<xref ref-type="fn" rid="fn3">*</xref></article-title>
+                    <article-title>Solución <italic>de heparina para prevenir</italic> oclusiones en catéteres de Hickman<sup>®</sup> un ensayo clínico aleatorizado<xref ref-type="fn" rid="fn3">*</xref></article-title>
                   </title-group>
                 </front-stub>
             </sub-article>
@@ -2067,11 +2067,11 @@ class MetadataWithStylesForArticleWithSubarticlesTests(unittest.TestCase):
                     """clinical trial"""
                     ),
                 "pt": (
-                    """Solução de heparina na prevenção de oclusão do """
+                    """Solução de <b>heparina</b> na prevenção de oclusão do """
                     """Cateter de Hickman<sup>®</sup> ensaio clínico """
                     """randomizado"""),
                 "es": (
-                    """Solución de heparina para prevenir oclusiones en """
+                    """Solución <i>de heparina para prevenir</i> oclusiones en """
                     """catéteres de Hickman<sup>®</sup> un ensayo clínico """
                     """aleatorizado"""),
             }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1224,10 +1224,10 @@ class FetchDocumentFrontTest(CommandTestMixin, unittest.TestCase):
 
     def test_call_returns_display_format(self):
         expected = {
-            'article-title': {
+            'article_title': {
                 "en": """Proposal for a telehealth concept in the translational research model""",
                 "pt": """Proposta conceitual de telessaúde no modelo da pesquisa translacional""",
             }
         }
         result = self.command(self.data)
-        self.assertEqual(expected, result['display-format'])
+        self.assertEqual(expected, result['display_format'])

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1207,3 +1207,27 @@ class RegisterDocumentVersionTest(CommandTestMixin, unittest.TestCase):
                     assets=assets,
                 )
             )
+
+
+class FetchDocumentFrontTest(CommandTestMixin, unittest.TestCase):
+    def setUp(self):
+        self.services, self.session = make_services()
+        self.command = self.services["sanitize_document_front"]
+        with open(
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "0034-8910-rsp-48-2-0347.xml",
+                ),
+                "rb"
+            ) as fixture:
+            self.data = fixture.read()
+
+    def test_call_returns_display_format(self):
+        expected = {
+            'article-title': {
+                "en": """Proposal for a telehealth concept in the translational research model""",
+                "pt": """Proposta conceitual de telessaúde no modelo da pesquisa translacional""",
+            }
+        }
+        result = self.command(self.data)
+        self.assertEqual(expected, result['display-format'])


### PR DESCRIPTION
#### O que esse PR faz?
Retornar no front, metadados (por  hora apenas título de artigo) com a "formatação" mantida 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
.

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1484

### Referências
https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/article-title.html