### PR TITLE
Ajusta a manipulação dos títulos quando contém ``xref``.

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -268,11 +268,11 @@ def display_format(
 ) -> dict:
     """
     (#PCDATA | email | ext-link | uri | inline-supplementary-material |
-     related-article | related-object | bold | fixed-case | italic | 
-     monospace | overline | roman | sans-serif | sc | strike | underline | 
-     ruby | alternatives | inline-graphic | inline-media | private-char | 
-     chem-struct | inline-formula | tex-math | mml:math | abbrev | index-term | 
-     index-term-range-end | milestone-end | milestone-start | named-content | 
+     related-article | related-object | bold | fixed-case | italic |
+     monospace | overline | roman | sans-serif | sc | strike | underline |
+     ruby | alternatives | inline-graphic | inline-media | private-char |
+     chem-struct | inline-formula | tex-math | mml:math | abbrev | index-term |
+     index-term-range-end | milestone-end | milestone-start | named-content |
      styled-content | fn | target | xref | sub | sup | break)*
     """
     metadata = {}
@@ -288,9 +288,9 @@ def display_format(
         for lang_node in xml.findall(lang_xpath):
             lang = lang_node.get('{http://www.w3.org/XML/1998/namespace}lang')
             for content_node in lang_node.findall(content_xpath):
-                _display_format_remove_xref(content_node)
                 _display_format_convert_bold_and_italic(content_node)
-                content = _display_format_get_content(content_node)
+                content = _display_format_remove_xref(
+                    _display_format_get_content(content_node))
                 if content and lang:
                     _display_format_update_output(
                         metadata, label, lang, content)
@@ -307,20 +307,18 @@ def _display_format_get_content(node):
     content = etree.tostring(node, encoding='utf-8').decode("utf-8")
     content = content[content.find(">")+1:]
     content = content[:content.rfind("</")]
-    return content
+    return content.strip()
 
 
-def _display_format_remove_xref(node):
-    for xref in node.findall(".//xref"):
-        p = xref.getparent()
-        p.remove(xref)
+def _display_format_remove_xref(text):
+    clean_text = re.compile('<\s*xref[^>]*>(.*?)<\s*/\s*xref>')
+    return re.sub(clean_text, '', text).strip()
 
 
 def _display_format_convert_bold_and_italic(node):
     for tag in ("bold", "italic"):
         for found in node.findall(".//{}".format(tag)):
             found.tag = tag[0]
-
 
 
 class Document:

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -288,9 +288,9 @@ def display_format(
         for lang_node in xml.findall(lang_xpath):
             lang = lang_node.get('{http://www.w3.org/XML/1998/namespace}lang')
             for content_node in lang_node.findall(content_xpath):
+                _display_format_remove_xref(content_node)
                 _display_format_convert_bold_and_italic(content_node)
-                content = _display_format_remove_xref(
-                    _display_format_get_content(content_node))
+                content = _display_format_get_content(content_node)
                 if content and lang:
                     _display_format_update_output(
                         metadata, label, lang, content)
@@ -310,9 +310,14 @@ def _display_format_get_content(node):
     return content.strip()
 
 
-def _display_format_remove_xref(text):
-    clean_text = re.compile('<\s*xref[^>]*>(.*?)<\s*/\s*xref>')
-    return re.sub(clean_text, '', text).strip()
+def _display_format_remove_xref(node):
+    for xref in node.findall(".//xref"):
+        p = xref.getparent()
+        tmp = etree.Element("tmp")
+        tmp.text = xref.tail
+        xref.addprevious(tmp)
+        p.remove(xref)
+        etree.strip_tags(node, "tmp")
 
 
 def _display_format_convert_bold_and_italic(node):

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -307,7 +307,7 @@ def _display_format_get_content(node):
     content = etree.tostring(node, encoding='utf-8').decode("utf-8")
     content = content[content.find(">")+1:]
     content = content[:content.rfind("</")]
-    return content.strip()
+    return content
 
 
 def _display_format_remove_xref(node):

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -2001,22 +2001,22 @@ class MetadataWithStylesForArticleWithTransTitlesTests(unittest.TestCase):
         result = domain.display_format(self.xml)
         expected = {
             "article_title": {
-                "pt": 
+                "pt":
                     ('Uma Reflexão de Professores sobre Demonstrações '
                         'Relativas à Irracionalidade de '
                         '<inline-formula><mml:math display="inline" id="m1">'
                         '<mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt>'
-                        '</mml:mrow></mml:math></inline-formula> '),
+                        '</mml:mrow></mml:math></inline-formula>'),
                 "en": (
                     """Teachers' Considerations on the Irrationality Proof """
                     """of <inline-formula><mml:math display="inline" """
                     """id="m2">"""
                     """<mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt>"""
-                    """</mml:mrow></mml:math></inline-formula> """),
+                    """</mml:mrow></mml:math></inline-formula>"""),
                 "es": (
                     """Español <inline-formula><mml:math display="inline" """
                     """id="m2"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn>"""
-                    """</mml:msqrt></mml:mrow></mml:math></inline-formula> """
+                    """</mml:msqrt></mml:mrow></mml:math></inline-formula>"""
                     ),
             }
         }
@@ -2065,6 +2065,56 @@ class MetadataWithStylesForArticleWithSubarticlesTests(unittest.TestCase):
                     """Heparin solution in the prevention of occlusions """
                     """in Hickman<sup>®</sup> catheters a randomized """
                     """clinical trial"""
+                    ),
+                "pt": (
+                    """Solução de <b>heparina</b> na prevenção de oclusão do """
+                    """Cateter de Hickman<sup>®</sup> ensaio clínico """
+                    """randomizado"""),
+                "es": (
+                    """Solución <i>de heparina para prevenir</i> oclusiones en """
+                    """catéteres de Hickman<sup>®</sup> un ensayo clínico """
+                    """aleatorizado"""),
+            }
+        }
+        self.assertDictEqual(expected, result)
+
+    def test_display_format_removes_xref_when_have_content_between_xref(self):
+        self.maxDiff=None
+        xml = (
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '''
+            <title-group>
+                <article-title> Pesquisa em ensino de química <xref ref-type="fn" rid="fn1"> <sup>1</sup> </xref> no Brasil entre 2002 e 2017 a partir de periódicos especializados <xref ref-type="fn" rid="fn2"> <sup>2</sup> </xref> </article-title>
+            </title-group>
+            '''
+            '</article-meta>'
+            '</front>'
+            '''
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                <title-group>
+                    <article-title>Solução de <bold>heparina</bold> na prevenção de oclusão do Cateter de Hickman<sup>®</sup> ensaio clínico randomizado<xref ref-type="fn" rid="fn2">*</xref></article-title>
+                </title-group>
+            </front-stub>
+            </sub-article>
+            <sub-article article-type="translation" id="s2" xml:lang="es">
+                <front-stub>
+                <title-group>
+                    <article-title>Solución <italic>de heparina para prevenir</italic> oclusiones en catéteres de Hickman<sup>®</sup> un ensayo clínico aleatorizado<xref ref-type="fn" rid="fn3">*</xref></article-title>
+                </title-group>
+                </front-stub>
+            </sub-article>
+            '''
+            '</article>'
+                ).encode("utf-8")
+        result = domain.display_format(xml)
+        expected = {
+            "article_title": {
+                "en": (
+                    """Pesquisa em ensino de química  no Brasil entre 2002 e """
+                    """2017 a partir de periódicos especializados"""
                     ),
                 "pt": (
                     """Solução de <b>heparina</b> na prevenção de oclusão do """


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR garante que não seja removido textos do título ao remover tags indesejadas com a tag `<xref>`

#### Onde a revisão poderia começar?

Por commit

#### Como este poderia ser testado manualmente?

Sugiro rodar os testes automáticos.

Comando para executar: 

```
python -m unittest tests/test_domain.py
```

#### Algum cenário de contexto que queira dar?

Esse PR tem como objetivo resolver o problema descrito no tíquete: https://github.com/scieloorg/opac/issues/2041

### Screenshots

Tela com a execução dos testes: 

![Captura de Tela 2022-03-31 às 10 54 44](https://user-images.githubusercontent.com/86991526/161072127-fcb99797-0e19-43e2-a2e9-bd1573b816ea.png)


#### Quais são tickets relevantes?

Essa correção tenta resolver o tíquete: https://github.com/scieloorg/opac/issues/2041

### Referências
N/A
