### PR TITLE
Corrige a seleção de `sub-article` que deve ser somente de tradução

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -281,13 +281,13 @@ def display_format(
     xpaths = [
         ("article_title", ".", ".//article-meta//article-title"),
         ("article_title", ".//article-meta//trans-title-group", ".//trans-title"),
-        ("article_title", ".//sub-article", ".//front-stub//article-title"),
+        ("article_title", ".//sub-article[@article-type='translation']", ".//front-stub//article-title"),
     ]
 
     for label, lang_xpath, content_xpath in xpaths:
         for lang_node in xml.findall(lang_xpath):
             lang = lang_node.get('{http://www.w3.org/XML/1998/namespace}lang')
-            for content_node in lang_node.findall(content_xpath):
+            for content_node in lang_node.xpath(content_xpath):
                 _display_format_remove_xref(content_node)
                 _display_format_convert_bold_and_italic(content_node)
                 content = _display_format_get_content(content_node)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(setup_path, "README.md")) as readme:
 
 setuptools.setup(
     name="scielo-kernel",
-    version="0.1rc14",
+    version="0.1rc16",
     author="SciELO Dev Team",
     author_email="scielo-dev@googlegroups.com",
     description="Kernel é o componente central da nova arquitetura de sistemas "


### PR DESCRIPTION
#### O que esse PR faz?
corrige a seleção do sub-article para obter o título do artigo

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ao acessar https://kernel.scielo.br/documents/hxrTrCR7sS8g5FG65nWrsWw/front

<img width="780" alt="Captura de Tela 2022-05-13 às 12 39 56" src="https://user-images.githubusercontent.com/505143/168318858-d594630e-278b-4a6f-9844-896845342b09.png">

O título `Pareceres` não deve ser apresentado porque ele não é um título de tradução e sim o título do sub-article que é um parecer.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2298

### Referências
n/a
